### PR TITLE
Run Mailpit tests (Mua) by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,21 @@ jobs:
             otp: '27.x'
             lint: lint
 
+    services:
+      mailpit:
+        image: axllent/mailpit:latest
+        ports:
+          - 1025:1025
+          - 8025:8025
+        env:
+          MP_SMTP_AUTH_ACCEPT_ANY: 1
+          MP_SMTP_AUTH_ALLOW_INSECURE: 1
+          options: >-
+            --health-cmd nc -zw3 localhost 1025
+            --health-interval 10s
+            --health-timeout 5s
+            --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,14 +29,6 @@ jobs:
         ports:
           - 1025:1025
           - 8025:8025
-        env:
-          MP_SMTP_AUTH_ACCEPT_ANY: 1
-          MP_SMTP_AUTH_ALLOW_INSECURE: 1
-          options: >-
-            --health-cmd nc -zw3 localhost 1025
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,4 +53,4 @@ jobs:
         if: matrix.lint
 
       - name: Run Tests
-        run: mix test
+        run: mix test --include mailpit


### PR DESCRIPTION
This PR enables Mailpit tests.

Mailpit is currently being used only in Swoosh.Adapters.MuaTest, but it can be used for Swoosh.Adapters.SMTP too.

Context: https://github.com/swoosh/swoosh/pull/982